### PR TITLE
Add support for drawing a hyperlink in QPdfEngine

### DIFF
--- a/src/gui/painting/qpdf.cpp
+++ b/src/gui/painting/qpdf.cpp
@@ -1182,6 +1182,34 @@ void QPdfEngine::drawTextItem(const QPointF &p, const QTextItem &textItem)
     *d->currentPage << "Q\n";
 }
 
+void QPdfEngine::drawHyperlink(const QRectF &r, const QUrl &url)
+{
+    Q_D(QPdfEngine);
+
+    const uint annot = d->addXrefEntry(-1);
+    const QByteArray urlascii = url.toEncoded();
+    int len = urlascii.size();
+    QVarLengthArray<char> url_esc(0);
+    for (int j = 0; j < len; j++) {
+        if (urlascii[j] == '(' || urlascii[j] == ')' || urlascii[j] == '\\')
+            url_esc.append('\\');
+        url_esc.append(urlascii[j]);
+    }
+    url_esc.append('\0');
+
+    char buf[256];
+    const QRectF rr = d->pageMatrix().mapRect(r);
+    d->xprintf("<<\n/Type /Annot\n/Subtype /Link\n/Rect [");
+    d->xprintf("%s ", qt_real_to_string(rr.left(), buf));
+    d->xprintf("%s ", qt_real_to_string(rr.top(), buf));
+    d->xprintf("%s ", qt_real_to_string(rr.right(), buf));
+    d->xprintf("%s", qt_real_to_string(rr.bottom(), buf));
+    d->xprintf("]\n/Border [0 0 0]\n/A <<\n");
+    d->xprintf("/Type /Action\n/S /URI\n/URI (%s)\n", url_esc.constData());
+    d->xprintf(">>\n>>\n");
+    d->xprintf("endobj\n");
+    d->currentPage->annotations.append(annot);
+}
 
 void QPdfEngine::updateState(const QPaintEngineState &state)
 {

--- a/src/gui/painting/qpdf_p.h
+++ b/src/gui/painting/qpdf_p.h
@@ -195,6 +195,8 @@ public:
 
     void updateState(const QPaintEngineState &state);
 
+    void drawHyperlink(const QRectF &r, const QUrl &url);
+
     int metric(QPaintDevice::PaintDeviceMetric metricType) const;
     Type type() const;
     // end reimplementations QPaintEngine


### PR DESCRIPTION
Adds the drawHyperlink method so that clients can draw a hyperlink
pointing to the specified URL at the specified rectangle. That new
method is to be used by GraphicContext::setURLForRect implementations
that want to render anchors as clickable links in PDF documents.

Task-number: QTBUG-44563
Change-Id: I7b0c602da37ee157d18115c531ab1b11fe304c13
Reviewed-by: Lars Knoll <lars.knoll@theqtcompany.com>