### PR TITLE
Explicitly link with -ldl when testing ICU in a static build.

### DIFF
--- a/src/3rdparty/icu_dependency.pri
+++ b/src/3rdparty/icu_dependency.pri
@@ -10,4 +10,7 @@ win32 {
     }
 } else {
     LIBS_PRIVATE += -licui18n -licuuc -licudata
+    CONFIG(static) {
+      LIBS_PRIVATE += -ldl
+    }
 }


### PR DESCRIPTION
On Unix, ICU has a dependency on libdl.  When ICU is used as a shared library,
this is automatically handled by the linker, but when it is used as a
static library, the link command must include -ldl explicitly.

(Found while testing Docker-based Linux builds.)