### PR TITLE
Fix for platform socklen_t on other C libraries than glibc.

### DIFF
--- a/mkspecs/linux-g++/qplatformdefs.h
+++ b/mkspecs/linux-g++/qplatformdefs.h
@@ -78,10 +78,10 @@
 
 #undef QT_SOCKLEN_T
 
-#if defined(__GLIBC__) && (__GLIBC__ >= 2)
-#define QT_SOCKLEN_T            socklen_t
-#else
+#if defined(__GLIBC__) && (__GLIBC__ < 2)
 #define QT_SOCKLEN_T            int
+#else
+#define QT_SOCKLEN_T            socklen_t
 #endif
 
 #if defined(_XOPEN_SOURCE) && (_XOPEN_SOURCE >= 500)


### PR DESCRIPTION
Rather than treating >=glibc-2 specially, we treat <glibc-2 specially
and all other libc implementations as POSIX.

This was found here http://patchwork.openembedded.org/patch/94947/ and
tested with armv6j-hardfloat-linux-uclibceabi and
armv6j-hardfloat-linux-musleabi.

Change-Id: I3850b1561a2e240f6564afedd80ce39407cc50b6
Reviewed-by: Oswald Buddenhagen <oswald.buddenhagen@theqtcompany.com>
Reviewed-by: Thiago Macieira <thiago.macieira@intel.com>