### PR TITLE
Give a nice error message when timing out synchronous requests

### DIFF
--- a/src/network/access/qhttpthreaddelegate.cpp
+++ b/src/network/access/qhttpthreaddelegate.cpp
@@ -403,6 +403,7 @@ void QHttpThreadDelegate::abortRequest()
     // Got aborted by the timeout timer
     if (synchronous) {
         incomingErrorCode = QNetworkReply::TimeoutError;
+        incomingErrorDetail = SYNCHRONOUS_REQUEST_TIMEOUT_MESSAGE;
         QMetaObject::invokeMethod(synchronousRequestLoop, "quit", Qt::QueuedConnection);
     } else {
         //only delete this for asynchronous mode or QNetworkAccessHttpBackend will crash - see QNetworkAccessHttpBackend::postRequest()

--- a/src/network/access/qnetworkreply.h
+++ b/src/network/access/qnetworkreply.h
@@ -43,6 +43,7 @@
 
 QT_BEGIN_NAMESPACE
 
+const QString SYNCHRONOUS_REQUEST_TIMEOUT_MESSAGE = QString("Synchronous Request Timeout");
 
 class QUrl;
 class QVariant;


### PR DESCRIPTION
- it used to be "Unknown Error"
- put the error message constant somewhere public, so users can use it
  to detect what kind of error it is.